### PR TITLE
Sprint 8: Kyle & Entoma   (Fixed) Added Title/Header for announcements

### DIFF
--- a/application/controllers/admin/CAdmin.php
+++ b/application/controllers/admin/CAdmin.php
@@ -625,7 +625,8 @@ class CAdmin extends CI_Controller {
 
 			// $now = NEW DateTime(NULL, new DateTimeZone('UTC'));
 
-			$data = array('announcementDetails' => $this->input->post('announcementDetails'),
+			$data = array('announcementTitle' => $this->input->post('announcementTitle'),
+						  'announcementDetails' => $this->input->post('announcementDetails'),
 						  'announcementStatus' => 'OnGoing',
 						  'addedBy' => $this->input->post('postedBy'),
 						  // 'addedAt' => $now->format('Y-m-d H:i:s')

--- a/application/views/admin/vAnnouncements.php
+++ b/application/views/admin/vAnnouncements.php
@@ -40,6 +40,7 @@
                 <thead class="">
                     <tr>
                       <th>#</th>
+                      <th>Title</th>
                       <th>Details</th>
                       <th>Date Posted</th>
                       <th>Status</th>
@@ -55,6 +56,7 @@
                                 $date = date("m-d-Y", strtotime($announcement->addedAt));
                                 echo  "<tr>
                                 <td id='announcementID'>".$announcement->announcementID."</td>
+                                <td>".strtoupper($announcement->announcementTitle)."</td>
                                 <td>".$announcement->announcementDetails."</td>
                                 <td>".$date."</td>
                                 <td>".$announcement->announcementStatus."</td>
@@ -100,11 +102,17 @@
       <?php echo form_open(site_url()."/admin/cAdmin/createAnnouncement", 'class="form-horizontal"'); ?>
           <!-- <form class="form-horizontal" method="POST" action="<?php echo site_url()?>/admin/cAdmin/createAnnouncement"> -->
 
+                <div class="form-group" >
+                  <label for="announcement-title" class="col-8 control-label">Title:</label>
+                  <div class="col-8">
+                    <input class="form-control" pattern="^[a-zA-Z0-9@,.;:_'\\s-]+$" title="Only valid characters are allowed." type="text" name="announcementTitle" placeholder="Enter Announcement Title" maxlength="100" required style="resize:none; overflow:hidden;"> 
+                  </div>
+                </div>
 
                 <div class="form-group" >
                   <label for="" class="col-8 control-label">Announcement:</label>
                   <div class="col-8">
-                    <textarea class="form-control" type="text" name="announcementDetails" required="" style="resize:none; overflow:hidden; min-height: 300px; max-height: 300px;"></textarea> 
+                    <textarea class="form-control" pattern="^[a-zA-Z0-9@,.;:_'\\s-]+$" title="Only valid characters are allowed." type="text" name="announcementDetails" required style="resize:none; overflow:hidden; min-height: 300px; max-height: 300px;"></textarea> 
                   </div>
                 </div>
 

--- a/application/views/user/vAnnouncementPage.php
+++ b/application/views/user/vAnnouncementPage.php
@@ -65,7 +65,7 @@
 
                                   <div class='box-body'>
                                     <div class='box-title'>
-                                      <h1><a href='#''>This Post Has No Heading</a></h1>
+                                      <h1>".(($announcement->announcementTitle)?strtoupper($announcement->announcementTitle):'THIS ANNOUNCEMENT HAS NO TITLE')."</h1>
                                     </div>
                                     <div class='box-summary'>
                                       <p>".$announcement->announcementDetails."</p>


### PR DESCRIPTION
Kyle Yap and Joseph Entoma
Issue: https://github.com/ploidddddd/purplekeep/issues/96

- Added Title Field for announcements
![image](https://user-images.githubusercontent.com/23441168/36973978-f289e5d4-20af-11e8-9843-f65701494432.png)
- Added validation input for title
![image](https://user-images.githubusercontent.com/23441168/36974041-3141fbd6-20b0-11e8-8411-3b9005a808a8.png)

- Display in Admin Announcement Table
![image](https://user-images.githubusercontent.com/23441168/36974053-3ebdd2bc-20b0-11e8-9f59-afaab8083d2a.png)

- Display in User's Announcement Page
![image](https://user-images.githubusercontent.com/23441168/36974160-9d01d4ae-20b0-11e8-9109-8a90825d980b.png)
